### PR TITLE
Cache services responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ venv.bak/
 # Ignore IDEs settings
 .vscode/
 .idea/
+
+# Ignore SQLite local database files
+*.db
+*.sqlite

--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ codecov = "*"
 python-telegram-bot = "*"
 python-decouple = "*"
 requests = "*"
+dataset = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1f35dd75178d820ba150ab709a18d0a402d5c5f97e7cc4afdc3dc37fe6dd9631"
+            "sha256": "e6e967a5d3ba2cba896399008070e7cf023db0514805c24d811fcad701a2700e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,12 @@
         ]
     },
     "default": {
+        "alembic": {
+            "hashes": [
+                "sha256:828dcaa922155a2b7166c4f36ec45268944e4055c86499bd14319b4c8c0094b7"
+            ],
+            "version": "==1.0.10"
+        },
         "asn1crypto": {
             "hashes": [
                 "sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87",
@@ -94,6 +100,14 @@
             ],
             "version": "==2.6.1"
         },
+        "dataset": {
+            "hashes": [
+                "sha256:06e6e8166a2ce12524ffbed97b82866caeaa2dd8e85ee65baccf3b815528e22e",
+                "sha256:22305959711499b0da0464298f3589cd33cccf84cfdcce91dae352a528cb4821"
+            ],
+            "index": "pypi",
+            "version": "==1.1.2"
+        },
         "future": {
             "hashes": [
                 "sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"
@@ -107,11 +121,57 @@
             ],
             "version": "==2.8"
         },
+        "mako": {
+            "hashes": [
+                "sha256:7165919e78e1feb68b4dbe829871ea9941398178fa58e6beedb9ba14acf63965"
+            ],
+            "version": "==1.0.10"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
+            ],
+            "version": "==1.1.1"
+        },
         "pycparser": {
             "hashes": [
                 "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
             ],
             "version": "==2.19"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+            ],
+            "version": "==2.8.0"
         },
         "python-decouple": {
             "hashes": [
@@ -119,6 +179,14 @@
             ],
             "index": "pypi",
             "version": "==3.1"
+        },
+        "python-editor": {
+            "hashes": [
+                "sha256:1bf6e860a8ad52a14c3ee1252d5dc25b2030618ed80c022598f00176adc8367d",
+                "sha256:51fda6bcc5ddbbb7063b2af7509e43bd84bfc32a4ff71349ec7847713882327b",
+                "sha256:5f98b069316ea1c2ed3f67e7f5df6c0d8f10b689964a4a811ff64f0106819ec8"
+            ],
+            "version": "==1.0.4"
         },
         "python-telegram-bot": {
             "hashes": [
@@ -142,6 +210,12 @@
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
+        },
+        "sqlalchemy": {
+            "hashes": [
+                "sha256:91c54ca8345008fceaec987e10924bf07dcab36c442925357e5a467b36a38319"
+            ],
+            "version": "==1.3.3"
         },
         "tornado": {
             "hashes": [

--- a/bot/loanbot.py
+++ b/bot/loanbot.py
@@ -118,7 +118,7 @@ def create_loan(update, context):
             "term": int(values[1]),
             "rate": float(values[2]) if n_values == 3 else 0.05,
             "date": datetime.now().isoformat(timespec="seconds"),
-            "client_id": context.user_data["client"]["id"],
+            "client_id": context.user_data["client"]["client_id"],
         }
         context.user_data["loan"] = loan
         deal = services.post_loan(loan)

--- a/bot/settings.py
+++ b/bot/settings.py
@@ -3,3 +3,4 @@ from decouple import config
 TELEGRAM_TOKEN = config("TELEGRAM_TOKEN", default="")
 LOG_LEVEL = config("LOG_LEVEL", default="INFO")
 LOAN_API = config("LOAN_API", default="http://localhost")
+DATABASE_URL = config("DATABASE_URL", default="sqlite:///:memory:")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def context():
 @pytest.fixture
 def client():
     return {
-        "id": "1e4c777d-ec05-4b0b-b4be-10cb5a0d1e82",
+        "client_id": "1e4c777d-ec05-4b0b-b4be-10cb5a0d1e82",
         "name": "Herman",
         "surname": "Melville",
         "email": "whale@pequod.ship",
@@ -34,6 +34,7 @@ def client():
 @pytest.fixture
 def loan():
     return {
+        "loan_id": "5a8e9343-3535-4981-b766-4e6a229ccb50",
         "amount": 1000.0,
         "term": 12,
         "rate": 0.05,

--- a/tests/test_loanbot.py
+++ b/tests/test_loanbot.py
@@ -92,7 +92,7 @@ def test_create_loan_no_values(m_services, update, context):
 @mock.patch("bot.loanbot.services")
 def test_create_loan_success(m_services, update, context):
     update.message.text = "1000.00 12"
-    context.user_data["client"] = {"id": "userid"}
+    context.user_data["client"] = {"client_id": "userid"}
     m_services.post_loan.return_value = {"installment": 85.61}
     out = loanbot.create_loan(update, context)
     assert m_services.post_loan.called_once

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -3,49 +3,133 @@ from unittest import mock
 from bot import services
 
 
+@mock.patch("bot.services.db")
 @mock.patch("bot.services.requests")
-def test_get_client_success(m_requests, client):
+def test_get_client_success(m_requests, m_db, client):
     data = [client]
     response = mock.Mock()
     response.status_code = 200
     response.json.return_value = data
     m_requests.get.return_value = response
-    client = services.get_client("70624771687")
+
+    table = mock.Mock()
+    table.find_one.return_value = None
+    db = {"clients": table}
+    m_db.__getitem__.side_effect = db.__getitem__
+    m_db.__iter__.side_effect = db.__iter__
+
+    cli = services.get_client("70624771687")
+
+    assert table.find_one.called_once
+    assert table.upsert.called_once
     assert m_requests.get.called_once
-    assert client == data[0]
+    assert response.json.called_once
+    assert cli == client
 
 
+@mock.patch("bot.services.db")
+@mock.patch("bot.services.requests")
+def test_get_client_cached(m_requests, m_db, client):
+    table = mock.Mock()
+    table.find_one.return_value = client
+    db = {"clients": table}
+    m_db.__getitem__.side_effect = db.__getitem__
+    m_db.__iter__.side_effect = db.__iter__
+
+    cli = services.get_client("70624771687")
+
+    assert table.find_one.called_once
+    assert not table.upsert.called
+    assert not m_requests.get.called
+    assert cli == client
+
+
+@mock.patch("bot.services.db")
+@mock.patch("bot.services.requests")
+def test_get_client_not_found(m_requests, m_db):
+    response = mock.Mock()
+    response.status_code = 200
+    response.json.return_value = []
+    m_requests.get.return_value = response
+
+    table = mock.Mock()
+    table.find_one.return_value = None
+    db = {"clients": table}
+    m_db.__getitem__.side_effect = db.__getitem__
+    m_db.__iter__.side_effect = db.__iter__
+
+    cli = services.get_client("70624771687")
+
+    assert table.find_one.called_once
+    assert not table.upsert.called
+    assert m_requests.get.called_once
+    assert response.json.called_once
+    assert not cli
+
+
+@mock.patch("bot.services.db")
 @mock.patch("bot.services.requests")
 @mock.patch("bot.loanbot.logger")
-def test_get_client_fail(m_logger, m_requests):
+def test_get_client_fail(m_logger, m_requests, m_db):
     response = mock.Mock()
     response.status_code = 500
     m_requests.get.return_value = response
-    client = services.get_client("70624771687")
+
+    table = mock.Mock()
+    table.find_one.return_value = None
+    db = {"clients": table}
+    m_db.__getitem__.side_effect = db.__getitem__
+    m_db.__iter__.side_effect = db.__iter__
+
+    cli = services.get_client("70624771687")
+
+    assert table.find_one.called_once
+    assert not table.upsert.called
     assert m_requests.get.called_once
+    assert not response.json.called
     assert m_logger.warning.called_once
-    assert not client
+    assert not cli
 
 
+@mock.patch("bot.services.db")
 @mock.patch("bot.services.requests")
-def test_post_loan_success(m_requests, loan):
+def test_post_loan_success(m_requests, m_db, loan):
     data = {"installment": 85.61}
     response = mock.Mock()
     response.status_code = 201
     response.json.return_value = data
     m_requests.post.return_value = response
+
+    table = mock.Mock()
+    db = {"loans": table}
+    m_db.__getitem__.side_effect = db.__getitem__
+    m_db.__iter__.side_effect = db.__iter__
+
     installment = services.post_loan(loan)
+
+    data.update(loan)
+
     assert m_requests.post.called_once
+    assert table.upsert.called_once
     assert installment == data
 
 
+@mock.patch("bot.services.db")
 @mock.patch("bot.services.requests")
 @mock.patch("bot.loanbot.logger")
-def test_post_loan_fail(m_logger, m_requests, loan):
+def test_post_loan_fail(m_logger, m_requests, m_db, loan):
     response = mock.Mock()
     response.status_code = 400
     m_requests.post.return_value = response
+
+    table = mock.Mock()
+    db = {"loans": table}
+    m_db.__getitem__.side_effect = db.__getitem__
+    m_db.__iter__.side_effect = db.__iter__
+
     installment = services.post_loan(loan)
+
     assert m_requests.post.called_once
+    assert not table.upsert.called
     assert m_logger.warning.called_once
     assert not installment


### PR DESCRIPTION
Because the API doesn’t provide some basic filters and the responses lack information, it was necessary to implement a local cache using a database in order to fill these gaps.

- Add dataset library to simplify database usage
- Change services to store responses
- Update tests
- Tell git to ignore local sqlite databases